### PR TITLE
Update running-gatewayd.md to handle Docker host connection for different setups

### DIFF
--- a/developing-plugins/grpc-api-reference.md
+++ b/developing-plugins/grpc-api-reference.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: gRPC API Reference
 description: GatewayD exposes a gRPC API that can be used to interact with the GatewayD plugin system. This API can be used by the GatewayD plugins and is available in the GatewayD SDK.

--- a/developing-plugins/index.md
+++ b/developing-plugins/index.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Developing Plugins
 nav_order: 4

--- a/developing-plugins/plugin-developers-guide.md
+++ b/developing-plugins/plugin-developers-guide.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 21:33:25
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Plugin Developers Guide
 description: Plugin developers' guide of GatewayD

--- a/developing-plugins/sdk-reference.md
+++ b/developing-plugins/sdk-reference.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: SDK Reference
 description: The GatewayD plugin SDK provides a number of interfaces, structs and methods to help you build your plugin.

--- a/developing-plugins/template-projects.md
+++ b/developing-plugins/template-projects.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Template Projects
 description: Template projects can be used to quickly get started with developing plugins.

--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Getting Started
 nav_order: 1

--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Installation
 description: How to install GatewayD and its plugins on different platforms and how to build it from source.

--- a/getting-started/running-gatewayd.md
+++ b/getting-started/running-gatewayd.md
@@ -32,7 +32,7 @@ docker run --rm --name postgres-test -p 5432:5432 -e POSTGRES_PASSWORD=postgres 
 Test your database by running the following command:
 
 ```bash
-DOCKER_HOST=$(ip addr show docker0 | grep inet | grep -v inet6 | awk -F' ' '{ print $2 }' | sed 's/\/16//g')
+DOCKER_HOST=$(if ip addr show docker0 > /dev/null 2>&1; then ip addr show docker0 | grep inet | grep -v inet6 | awk -F' ' '{ print $2 }' | sed 's/\/.*//'; else echo "host.docker.internal"; fi);
 docker exec -it postgres-test psql postgresql://postgres:postgres@${DOCKER_HOST}:5432/postgres -c "\d"
 ```
 
@@ -120,7 +120,6 @@ Running GatewayD will produce the following log output, which means that Gateway
 GatewayD is running on the host, while PostgreSQL is running inside a container. You can run the following command to test it. Notice that `${DOCKER_HOST}` holds the IP address of the host machine, that is accessible from inside the container.
 
 ```bash
-DOCKER_HOST=$(ip addr show docker0 | grep inet | grep -v inet6 | awk -F' ' '{ print $2 }' | sed 's/\/16//g')
 docker exec -it postgres-test psql postgresql://postgres:postgres@${DOCKER_HOST}:15432/postgres
 ```
 

--- a/getting-started/running-gatewayd.md
+++ b/getting-started/running-gatewayd.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:18:45
 layout: default
 title: Running GatewayD
 description: How to run GatewayD and test it with psql

--- a/getting-started/welcome.md
+++ b/getting-started/welcome.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Welcome
 description: Introduction to GatewayD and its key features

--- a/miscellaneous/glossary.md
+++ b/miscellaneous/glossary.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Glossary
 description: Glossary of GatewayD terms

--- a/miscellaneous/index.md
+++ b/miscellaneous/index.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Miscellaneous
 nav_order: 6

--- a/miscellaneous/telemetry-and-usage-report.md
+++ b/miscellaneous/telemetry-and-usage-report.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Telemetry and Usage Report
 description: Telemetry and usage report of GatewayD

--- a/plugins/gatewayd-plugin-cache.md
+++ b/plugins/gatewayd-plugin-cache.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: gatewayd-plugin-cache
 description: GatewayD plugin for caching query results in Redis.

--- a/plugins/gatewayd-plugin-js.md
+++ b/plugins/gatewayd-plugin-js.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: gatewayd-plugin-js
 description: GatewayD plugin for running JS functions as hooks.

--- a/plugins/index.md
+++ b/plugins/index.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Plugins
 nav_order: 5

--- a/using-gatewayd/API.md
+++ b/using-gatewayd/API.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: API
 description: GatewayD exposes a gRPC API with an HTTP gateway for querying and managing the `gatewayd` process and its plugins.

--- a/using-gatewayd/Act.md
+++ b/using-gatewayd/Act.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Act
 description: Act is a policy engine that supports signals, policies and actions. It is used to automate the execution of business rules.

--- a/using-gatewayd/CLI.md
+++ b/using-gatewayd/CLI.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: CLI
 description: GatewayD is a CLI application that runs on Windows, Linux-based distributions and macOS.

--- a/using-gatewayd/clients.md
+++ b/using-gatewayd/clients.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Clients
 description: Client object is a client that can connect to the database servers over TCP, UDP and Unix Domain Socket.

--- a/using-gatewayd/configuration.md
+++ b/using-gatewayd/configuration.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Configuration
 description: GatewayD is fully configurable via various sources, including default values, YAML config files, environment variables, CLI flags and plugins.

--- a/using-gatewayd/connection-lifecycle.md
+++ b/using-gatewayd/connection-lifecycle.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Connection Lifecycle
 description: Connection Lifecycle of GatewayD

--- a/using-gatewayd/global-configuration/api.md
+++ b/using-gatewayd/global-configuration/api.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: API
 description: GatewayD gRPC API configuration

--- a/using-gatewayd/global-configuration/clients.md
+++ b/using-gatewayd/global-configuration/clients.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Clients
 description: GatewayD client configuration

--- a/using-gatewayd/global-configuration/index.md
+++ b/using-gatewayd/global-configuration/index.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Global Configuration
 nav_order: 2

--- a/using-gatewayd/global-configuration/loggers.md
+++ b/using-gatewayd/global-configuration/loggers.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Loggers
 description: GatewayD logger configuration

--- a/using-gatewayd/global-configuration/metrics.md
+++ b/using-gatewayd/global-configuration/metrics.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Metrics
 description: GatewayD metrics configuration

--- a/using-gatewayd/global-configuration/pools.md
+++ b/using-gatewayd/global-configuration/pools.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Pools
 description: GatewayD pool configuration

--- a/using-gatewayd/global-configuration/proxies.md
+++ b/using-gatewayd/global-configuration/proxies.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Proxies
 description: GatewayD proxy configuration

--- a/using-gatewayd/global-configuration/servers.md
+++ b/using-gatewayd/global-configuration/servers.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Servers
 description: GatewayD server configuration

--- a/using-gatewayd/index.md
+++ b/using-gatewayd/index.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Using GatewayD
 nav_order: 2

--- a/using-gatewayd/observability.md
+++ b/using-gatewayd/observability.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Observability
 description: Observability is a first-class citizen of GatewayD. It generates logs, metrics and traces to make it easier to see what is going on inside.

--- a/using-gatewayd/plugins-configuration/general-configurations.md
+++ b/using-gatewayd/plugins-configuration/general-configurations.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: General configurations
 description: General configurations for plugins

--- a/using-gatewayd/plugins-configuration/index.md
+++ b/using-gatewayd/plugins-configuration/index.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Plugins Configuration
 nav_order: 3

--- a/using-gatewayd/plugins-configuration/plugins-configuration.md
+++ b/using-gatewayd/plugins-configuration/plugins-configuration.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Plugins configuration
 description: GatewayD plugins configuration

--- a/using-gatewayd/pools.md
+++ b/using-gatewayd/pools.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Pools
 description: GatewayD has a generic internal pool object that is used to manage plugins and connections.

--- a/using-gatewayd/protocols.md
+++ b/using-gatewayd/protocols.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Protocols
 description: GatewayD is application layer protocol-agnostic. This means that GatewayD *can* practically support any protocol in the application layer, or L7.

--- a/using-gatewayd/proxies.md
+++ b/using-gatewayd/proxies.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Proxies
 description: Proxy object is used to create a binding between incoming connections from the database clients to the database servers.

--- a/using-gatewayd/servers.md
+++ b/using-gatewayd/servers.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Servers
 description: Server is an object that listens on an address:port pair and accepts connections from database clients.

--- a/using-plugins/hook-registry.md
+++ b/using-plugins/hook-registry.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Hook registry
 description: The hook registry is a central place where all hooks are registered and executed. It is used by the plugin registry to register and execute plugin hooks.

--- a/using-plugins/hooks.md
+++ b/using-plugins/hooks.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Hooks
 description: Plugins can be used to modify the connection lifecycle. Each step in the connection lifecycle is represented by one or more plugin hook(s). Plugins can register themselves to be called when a specific hook is triggered.

--- a/using-plugins/index.md
+++ b/using-plugins/index.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Using Plugins
 nav_order: 3

--- a/using-plugins/plugin-registry.md
+++ b/using-plugins/plugin-registry.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Plugin registry
 description: The plugin registry is a central place where all plugins are loaded, configured and executed, and also the main entry point for all plugins.

--- a/using-plugins/plugin-types.md
+++ b/using-plugins/plugin-types.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Plugin types
 description: >

--- a/using-plugins/plugins.md
+++ b/using-plugins/plugins.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Plugins
 description: Plugins play a very important role in GatewayD for adding support for different databases. They are the building blocks of GatewayD, and they are responsible for the majority of the functionality of GatewayD.

--- a/using-plugins/proposals.md
+++ b/using-plugins/proposals.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-11 20:53:27
+last_modified_date: 2024-05-31 20:16:38
 layout: default
 title: Proposals
 description: GatewayD proposals are used to propose new ideas and features for GatewayD.


### PR DESCRIPTION
## Description
This PR addresses the issue of setting the Docker host variable when running on Docker Desktop. Due to the networking implementation in Docker Desktop, the `docker0` bridge interface is not present on the host. Instead, we can use the DNS name (https://docs.docker.com/desktop/networking/#use-cases-and-workarounds)

## Changes Made
- Added instructions for setting the `DOCKER_HOST` variable to `host.docker.internal` when using Docker Desktop.
- Removed the extra definition of DOCKER_HOST in step 5 because it is already defined in step 1.

## Context
When running on Docker Desktop, the absence of the docker0 bridge interface on the host can lead to confusion regarding how to correctly set up the Docker host variable.