### PR TITLE
Generate timestamps on pre-commit

### DIFF
--- a/.githooks/pre-commit/01-update-last-modified-date
+++ b/.githooks/pre-commit/01-update-last-modified-date
@@ -1,11 +1,17 @@
-#!/usr/bin/bash
-# Replace `last_modified_date` timestamp with current time
-# This script is used to update the `last_modified_date` timestamp in the frontmatter of all Markdown files in the current directory and subdirectories.
+#!/usr/bin/env bash
 
-# Loop through all Markdown files in the current directory and subdirectories
-find . -type f -name "*.md" | while read file; do
-    # Check if the file contains a frontmatter block
-    if grep -q "^---" "$file"; then
+# Replace `last_modified_date` timestamp with current time
+# This script is used to update the `last_modified_date` timestamp
+# in the frontmatter of staged Markdown files.
+
+# Get the list of staged Markdown files
+staged_files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.md$')
+
+# Loop through each staged Markdown file
+echo "$staged_files" | while read file; do
+    # Check if the file exists and contains a frontmatter block
+    if [[ -f "$file" ]] && grep -q "^---" "$file"; then
+        echo "Updating last_modified_date in $file"
         # Get the last modified timestamp of the file
         last_modified_timestamp=$(stat -c %Y "$file")
 
@@ -19,5 +25,8 @@ find . -type f -name "*.md" | while read file; do
             # If last_modified_date does not exist, add it after the first frontmatter delimiter
             sed -i "/^---/a last_modified_date: $last_modified_datetime_utc" "$file"
         fi
+
+        # Stage the updated file
+        git add "$file"
     fi
 done

--- a/README.md
+++ b/README.md
@@ -61,3 +61,11 @@ The first parameter is the repository name in the format `owner/repo`. The secon
 For private repositories, you can set the `GITHUB_TOKEN` environment variable with a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) to authenticate with GitHub. If the token is not provided, the tag will be displayed as `unknown`.
 
 The tag can be used multiple times in the same page. A single request will be made to the GitHub API to retrieve the latest tag name for each repository.
+
+## Contributing
+
+We welcome contributions from everyone. Just open an [issue](https://github.com/gatewayd-io/docs/issues) or send us a [pull request](https://github.com/gatewayd-io/docs/pulls).
+
+## License
+
+GatewayD is licensed under the [Affero General Public License v3.0](https://github.com/gatewayd-io/docs/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@
     <a href="https://docs.gatewayd.io/">Documentation</a>
 </p>
 
+> [!IMPORTANT]
+> The pre-commit hook is used to update the `last_modified_date` field in the frontmatter for each page. It will run automatically upon committing changes if you run the following commands to enable them:
+>
+> ```bash
+> ln .git/hooks/pre-commit .githooks/pre-commit/01-update-last-modified-date
+> git config core.hooksPath .githooks
+> ```
+
 ## Running the docs locally
 
 The docs are built using [Jekyll](https://jekyllrb.com/) and the [just-the-docs](https://just-the-docs.github.io/just-the-docs/) theme. To run the docs locally, you need to have Git and Ruby installed. Then, install Jekyll and `bundler`:
@@ -53,11 +61,3 @@ The first parameter is the repository name in the format `owner/repo`. The secon
 For private repositories, you can set the `GITHUB_TOKEN` environment variable with a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) to authenticate with GitHub. If the token is not provided, the tag will be displayed as `unknown`.
 
 The tag can be used multiple times in the same page. A single request will be made to the GitHub API to retrieve the latest tag name for each repository.
-
-## Latest modified date
-
-The `generate_last_modified_data.sh` script is used to generate the `last_modified_date` data in the frontmatter for each page. It should be run manually before pushing the changes to the `main` branch.
-
-```bash
-./generate_last_modified_data.sh
-```


### PR DESCRIPTION
This PR updates the old `generate_last_modified_data.sh` to be executed as a pre-commit hook when committing a change that involves doc pages. The script is updated to only update the timestamp on files that has actually been changed and not all the files and since it runs as a pre-commit hook (if enabled), it'll add the changes to the same commit, thus preventing unnecessary extra commits for modification of the last date and time field in the frontmatter.