### PR TITLE
Update plugin docs for sql-ids-ips, cache, and js plugins

### DIFF
--- a/plugins/gatewayd-plugin-cache.md
+++ b/plugins/gatewayd-plugin-cache.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-09-14 13:37:00
+last_modified_date: 2026-02-22 00:27:00
 layout: default
 title: gatewayd-plugin-cache
 description: GatewayD plugin for caching query results in Redis.
@@ -85,6 +85,7 @@ plugins:
       - PERIODIC_INVALIDATOR_START_DELAY=1m
       - EXIT_ON_STARTUP_ERROR=False
       - SENTRY_DSN=https://70eb1abcd32e41acbdfc17bc3407a543@o4504550475038720.ingest.sentry.io/4505342961123328
+      - SCAN_COUNT=1000
       - CACHE_CHANNEL_BUFFER_SIZE=100
     checksum: 3988e10aefce2cd9b30888eddd2ec93a431c9018a695aea1cea0dac46ba91cae
 ```
@@ -106,6 +107,7 @@ plugins:
 | `PERIODIC_INVALIDATOR_INTERVAL`    | The interval for periodic cache invalidation.                                                                                                    | `1m`                                                                                           |
 | `PERIODIC_INVALIDATOR_START_DELAY` | The delay before starting periodic cache invalidation.                                                                                           | `1m`                                                                                           |
 | `EXIT_ON_STARTUP_ERROR`            | Whether to exit the plugin if there is an error during startup.                                                                                  | `False`                                                                                        |
+| `SCAN_COUNT`                       | The number of keys to scan per iteration during periodic cache invalidation.                                                                     | `1000`                                                                                         |
 | `SENTRY_DSN`                       | Sentry DSN. Set to empty string to disable Sentry.                                                                                               | `https://70eb1abcd32e41acbdfc17bc3407a543@o4504550475038720.ingest.sentry.io/4505342961123328` |
 | `CACHE_CHANNEL_BUFFER_SIZE`        | The buffer size for the cache channel.                                                                                                           | `100`                                                                                          |
 

--- a/plugins/gatewayd-plugin-js.md
+++ b/plugins/gatewayd-plugin-js.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2024-05-31 20:16:38
+last_modified_date: 2026-02-22 00:28:00
 layout: default
 title: gatewayd-plugin-js
 description: GatewayD plugin for running JS functions as hooks.
@@ -26,10 +26,21 @@ The gatewayd-plugin-js is a GatewayD plugin for running JS functions as hooks an
 > }
 > ```
 
+## Helper Functions
+
+The following built-in helper functions are available in the JavaScript runtime:
+
+| Function   | Description                                                                                                    |
+| ---------- | -------------------------------------------------------------------------------------------------------------- |
+| `parseSQL` | Parses a SQL query string and returns a stringified JSON representation of the parsed AST. Takes one argument. |
+| `btoa`     | Encodes a string to base64. Takes one argument.                                                                |
+| `atob`     | Decodes a base64-encoded string. Takes one argument.                                                           |
+
 ## Features
 
 - Run JS functions as hooks
 - Helper functions for common tasks such as parsing incoming queries
+- Thread-safe JavaScript execution via mutex-protected runtime
 - Support for running multiple JS functions as hooks
 - Prometheus metrics for monitoring
 - Logging
@@ -67,23 +78,30 @@ plugins:
   - name: gatewayd-plugin-js
     enabled: True
     localPath: ../gatewayd-plugin-js/gatewayd-plugin-js
+    url: github.com/gatewayd-io/gatewayd-plugin-js@latest
     args: ["--log-level", "info"]
     env:
       - MAGIC_COOKIE_KEY=GATEWAYD_PLUGIN
       - MAGIC_COOKIE_VALUE=5712b87aa5d7e9f9e9ab643e6603181c5b796015cb1c09d6f5ada882bf2a1872
       - SCRIPT_PATH=./scripts/index.js
+      - METRICS_ENABLED=True
+      - METRICS_UNIX_DOMAIN_SOCKET=/tmp/gatewayd-plugin-js.sock
+      - METRICS_PATH=/metrics
       - SENTRY_DSN=https://439b580ade4a947cf16e5cfedd18f51f@o4504550475038720.ingest.sentry.io/4506475229413376
     checksum: d310772152467d9c6ab4ba17fd9dd40d3f724dee4aa014a722e1865d91744a4f
 ```
 
 ### Environment variables
 
-| Name                 | Description                                                                  | Default                                                                                        |
-| -------------------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `MAGIC_COOKIE_KEY`   | The key for the magic cookie.                                                | `GATEWAYD_PLUGIN`                                                                              |
-| `MAGIC_COOKIE_VALUE` | The value for the magic cookie.                                              | `5712b87aa5d7e9f9e9ab643e6603181c5b796015cb1c09d6f5ada882bf2a1872`                             |
-| `SCRIPT_PATH`        | The path to the JS file that contains the functions to be executed as hooks. | `./scripts/index.js`                                                                           |
-| `SENTRY_DSN`         | Sentry DSN. Set to empty string to disable Sentry.                           | `https://439b580ade4a947cf16e5cfedd18f51f@o4504550475038720.ingest.sentry.io/4506475229413376` |
+| Name                         | Description                                                                                   | Default                                                                                        |
+| ---------------------------- | --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `MAGIC_COOKIE_KEY`           | The key for the magic cookie.                                                                 | `GATEWAYD_PLUGIN`                                                                              |
+| `MAGIC_COOKIE_VALUE`         | The value for the magic cookie.                                                               | `5712b87aa5d7e9f9e9ab643e6603181c5b796015cb1c09d6f5ada882bf2a1872`                             |
+| `SCRIPT_PATH`                | The path to the JS file that contains the functions to be executed as hooks.                  | `./scripts/index.js`                                                                           |
+| `METRICS_ENABLED`            | Whether to enable metrics.                                                                    | `True`                                                                                         |
+| `METRICS_UNIX_DOMAIN_SOCKET` | The path to the Unix domain socket for exposing metrics. This must be accessible to GatewayD. | `/tmp/gatewayd-plugin-js.sock`                                                                 |
+| `METRICS_PATH`               | The path for exposing metrics.                                                                | `/metrics`                                                                                     |
+| `SENTRY_DSN`                 | Sentry DSN. Set to empty string to disable Sentry.                                            | `https://439b580ade4a947cf16e5cfedd18f51f@o4504550475038720.ingest.sentry.io/4506475229413376` |
 
 ### Command-line arguments
 

--- a/plugins/gatewayd-plugin-sql-ids-ips.md
+++ b/plugins/gatewayd-plugin-sql-ids-ips.md
@@ -1,5 +1,5 @@
 ---
-last_modified_date: 2026-02-21 21:44:00
+last_modified_date: 2026-02-22 00:27:00
 layout: default
 title: gatewayd-plugin-sql-ids-ips
 description: GatewayD plugin for SQL injection detection and prevention.
@@ -34,7 +34,18 @@ The `gatewayd-plugin-sql-ids-ips` is a security-focused GatewayD plugin designed
 
 ## DeepSQLi
 
-The plugin must be used in conjunction with DeepSQLi, a deep-learning model for SQL injection detection. DeepSQLi is available as a separate service and must be started before the plugin. For more information, refer to the [DeepSQLi documentation](https://github.com/gatewayd-io/DeepSQLi).
+The plugin must be used in conjunction with [DeepSQLi](https://github.com/gatewayd-io/DeepSQLi), a deep-learning model for SQL injection detection. DeepSQLi uses a CNN-BiLSTM architecture with a custom SQL tokenizer to classify queries as malicious or legitimate.
+
+DeepSQLi is available as a Docker container and must be started before the plugin:
+
+```bash
+cd DeepSQLi
+docker compose up -d prediction-api
+```
+
+The prediction API exposes a `/predict` endpoint on port 8000 by default, along with a `/health` endpoint for health checks. Configure the plugin to point to this address via the `PREDICTION_API_ADDRESS` environment variable.
+
+For more information, refer to the [DeepSQLi documentation](https://github.com/gatewayd-io/DeepSQLi).
 
 ## Installation
 
@@ -71,6 +82,7 @@ plugins:
       - METRICS_UNIX_DOMAIN_SOCKET=/tmp/gatewayd-plugin-sql-ids-ips.sock
       - METRICS_PATH=/metrics
       - PREDICTION_API_ADDRESS=http://localhost:8000
+      - PREDICTION_TIMEOUT=10
       - THRESHOLD=0.8
       - ENABLE_LIBINJECTION=True
       - LIBINJECTION_PERMISSIVE_MODE=True
@@ -86,24 +98,25 @@ plugins:
 
 ## Environment Variables
 
-| Name                           | Description                                                                                   | Default                                                                                                           |
-| ------------------------------ | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `MAGIC_COOKIE_KEY`             | The key for the magic cookie.                                                                 | `GATEWAYD_PLUGIN`                                                                                                 |
-| `MAGIC_COOKIE_VALUE`           | The value for the magic cookie.                                                               | `5712b87aa5d7e9f9e9ab643e6603181c5b796015cb1c09d6f5ada882bf2a1872`                                                |
-| `METRICS_ENABLED`              | Whether to enable metrics.                                                                    | `True`                                                                                                            |
-| `METRICS_UNIX_DOMAIN_SOCKET`   | The path to the Unix domain socket for exposing metrics. This must be accessible to GatewayD. | `/tmp/gatewayd-plugin-sql-ids-ips.sock`                                                                           |
-| `METRICS_PATH`                 | The path for exposing metrics.                                                                | `/metrics`                                                                                                        |
-| `PREDICTION_API_ADDRESS`       | The address for the prediction API server.                                                    | `http://localhost:8000`                                                                                           |
-| `THRESHOLD`                    | The threshold for the prediction confidence score.                                            | `0.8`                                                                                                             |
-| `ENABLE_LIBINJECTION`          | Whether to enable syntax-based detection using `libinjection`.                                | `True`                                                                                                            |
-| `LIBINJECTION_PERMISSIVE_MODE` | Whether to enable permissive mode for `libinjection`.                                         | `True`                                                                                                            |
-| `RESPONSE_TYPE`                | The response type for SQL injection attempts. Choose between `error` or `empty`.              | `error`                                                                                                           |
-| `ERROR_SEVERITY`               | The severity level for the error response.                                                    | `EXCEPTION`. See [this](https://www.postgresql.org/docs/current/protocol-error-fields.html) for more information. |
-| `ERROR_NUMBER`                 | The error number for the error response.                                                      | `42000`. See [this](https://www.postgresql.org/docs/current/errcodes-appendix.html) for more information.         |
-| `ERROR_MESSAGE`                | The error message for the error response.                                                     | `SQL injection detected`                                                                                          |
-| `ERROR_DETAIL`                 | The error detail for the error response.                                                      | `Back off, you're not welcome here.`                                                                              |
-| `LOG_LEVEL`                    | The log level for the plugin.                                                                 | `error`                                                                                                           |
-| `SENTRY_DSN`                   | Sentry DSN. Set to empty string to disable Sentry.                                            | `https://379ef59ea0c55742957b06c94bc496e1@o4504550475038720.ingest.us.sentry.io/4507282732810240`                 |
+| Name                           | Description                                                                                                                                           | Default                                                                                                           |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `MAGIC_COOKIE_KEY`             | The key for the magic cookie.                                                                                                                         | `GATEWAYD_PLUGIN`                                                                                                 |
+| `MAGIC_COOKIE_VALUE`           | The value for the magic cookie.                                                                                                                       | `5712b87aa5d7e9f9e9ab643e6603181c5b796015cb1c09d6f5ada882bf2a1872`                                                |
+| `METRICS_ENABLED`              | Whether to enable metrics.                                                                                                                            | `True`                                                                                                            |
+| `METRICS_UNIX_DOMAIN_SOCKET`   | The path to the Unix domain socket for exposing metrics. This must be accessible to GatewayD.                                                         | `/tmp/gatewayd-plugin-sql-ids-ips.sock`                                                                           |
+| `METRICS_PATH`                 | The path for exposing metrics.                                                                                                                        | `/metrics`                                                                                                        |
+| `PREDICTION_API_ADDRESS`       | The address for the prediction API server.                                                                                                            | `http://localhost:8000`                                                                                           |
+| `PREDICTION_TIMEOUT`           | Timeout in seconds for the prediction API request. If the API does not respond within this time, the request falls back to libinjection (if enabled). | `10`                                                                                                              |
+| `THRESHOLD`                    | The threshold for the prediction confidence score.                                                                                                    | `0.8`                                                                                                             |
+| `ENABLE_LIBINJECTION`          | Whether to enable syntax-based detection using `libinjection`.                                                                                        | `True`                                                                                                            |
+| `LIBINJECTION_PERMISSIVE_MODE` | Whether to enable permissive mode for `libinjection`.                                                                                                 | `True`                                                                                                            |
+| `RESPONSE_TYPE`                | The response type for SQL injection attempts. Choose between `error` or `empty`.                                                                      | `error`                                                                                                           |
+| `ERROR_SEVERITY`               | The severity level for the error response.                                                                                                            | `EXCEPTION`. See [this](https://www.postgresql.org/docs/current/protocol-error-fields.html) for more information. |
+| `ERROR_NUMBER`                 | The error number for the error response.                                                                                                              | `42000`. See [this](https://www.postgresql.org/docs/current/errcodes-appendix.html) for more information.         |
+| `ERROR_MESSAGE`                | The error message for the error response.                                                                                                             | `SQL injection detected`                                                                                          |
+| `ERROR_DETAIL`                 | The error detail for the error response.                                                                                                              | `Back off, you're not welcome here.`                                                                              |
+| `LOG_LEVEL`                    | The log level for the plugin.                                                                                                                         | `error`                                                                                                           |
+| `SENTRY_DSN`                   | Sentry DSN. Set to empty string to disable Sentry.                                                                                                    | `https://379ef59ea0c55742957b06c94bc496e1@o4504550475038720.ingest.us.sentry.io/4507282732810240`                 |
 
 ### Command-line arguments
 


### PR DESCRIPTION
## Summary

Updates documentation for three plugins to reflect recent code changes:

### gatewayd-plugin-sql-ids-ips
- Add `PREDICTION_TIMEOUT` environment variable documentation (new in v0.4.5)
- Expand DeepSQLi section with Docker deployment instructions and `/health` endpoint

### gatewayd-plugin-cache
- Add missing `SCAN_COUNT` environment variable documentation

### gatewayd-plugin-js
- Add helper functions reference table (`parseSQL`, `btoa`, `atob`)
- Document missing metrics environment variables (`METRICS_ENABLED`, `METRICS_UNIX_DOMAIN_SOCKET`, `METRICS_PATH`)
- Add `url` field to config sample
- Note thread-safe JavaScript execution

## Related PRs
- https://github.com/gatewayd-io/gatewayd-plugin-sql-ids-ips/pull/29
- https://github.com/gatewayd-io/DeepSQLi/pull/12
- https://github.com/gatewayd-io/gatewayd-plugin-js/pull/11
- https://github.com/gatewayd-io/gatewayd-plugin-cache/pull/87


Made with [Cursor](https://cursor.com)